### PR TITLE
chore: fix aarch64 builds for http-source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,9 @@ test:
 	bats ./tests/get-test-full.bats
 	bats ./tests/post-test.bats
 
+
+aarch64-linux: TARGET=aarch64-unknown-linux-musl
+aarch64-linux: zigbuild
+
+zigbuild:
+	cargo zigbuild --target ${TARGET} -p http-source

--- a/crates/http-source/Cargo.toml
+++ b/crates/http-source/Cargo.toml
@@ -24,5 +24,10 @@ tokio = { version = "1.23", default-features = false, features = ["time"]}
 fluvio = { git = "https://github.com/infinyon/fluvio", tag = "v0.10.4"}
 fluvio-connector-common = { git = "https://github.com/infinyon/fluvio", tag = "v0.10.4", features = ["derive"]}
 
+# workaround for building zstd for aarch64
+# https://github.com/gyscos/zstd-rs/issues/177
+[dependencies.zstd-sys]
+version = "2.0"
+
 [dev-dependencies]
 mockito = { version = "0.31", default-features = false}


### PR DESCRIPTION
allows zigbuild cross builds to link
`cargo zigbuild --target aarch64-unknown-linux-musl -p http-source`