### PR TITLE
Websocket source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite 0.2.13",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "async-task"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +446,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "async-tungstenite"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b30ef0ea5c20caaa54baea49514a206308989c68be7ecd86c7f956e4da6378"
+dependencies = [
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project-lite 0.2.13",
+ "tungstenite 0.13.0",
 ]
 
 [[package]]
@@ -966,6 +1001,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "debugid"
@@ -1896,7 +1937,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap 2.2.2",
  "slab",
  "tokio",
@@ -1982,13 +2023,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
  "pin-project-lite 0.2.13",
 ]
 
@@ -2010,6 +2062,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-std",
+ "async-stream",
  "async-trait",
  "bytes",
  "encoding_rs",
@@ -2024,6 +2077,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
+ "tungstenite 0.21.0",
  "url",
 ]
 
@@ -2088,7 +2143,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "httparse",
  "httpdate",
@@ -2192,6 +2247,15 @@ name = "infer"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
+
+[[package]]
+name = "input_buffer"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
+dependencies = [
+ "bytes",
+]
 
 [[package]]
 name = "instant"
@@ -2478,6 +2542,7 @@ dependencies = [
  "async-std",
  "serde",
  "tide",
+ "tide-websockets",
 ]
 
 [[package]]
@@ -3037,7 +3102,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "hyper-tls",
@@ -3300,12 +3365,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
 dependencies = [
  "sha1_smol",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3475,7 +3564,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha1",
+ "sha1 0.6.1",
  "syn 1.0.109",
 ]
 
@@ -3694,6 +3783,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tide-websockets"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3592c5cb5cb1b7a2ff3a0e5353170c1bb5b104b2f66dd06f73304169b52cc725"
+dependencies = [
+ "async-dup",
+ "async-std",
+ "async-tungstenite",
+ "base64 0.13.1",
+ "futures-util",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "sha-1",
+ "tide",
+]
+
+[[package]]
 name = "time"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3793,6 +3900,18 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.13",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -3928,6 +4047,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fe8dada8c1a3aeca77d6b51a4f1314e0f4b8e438b7b1b71e3ddaca8080e4093"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "bytes",
+ "http 0.2.11",
+ "httparse",
+ "input_buffer",
+ "log",
+ "rand 0.8.5",
+ "sha-1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.0.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1 0.10.6",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4003,6 +4161,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ test:
 	bats ./tests/post-test.bats
 	bats ./tests/get-time-test.bats
 	bats ./tests/get-smartmodule-test.bats
+	bats ./tests/websocket-test.bats
 
 cloud_e2e_test:
 	bats ./tests/cloud-http-get-test.bats

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 Read HTTP Responses given input HTTP request configuration options and produce them
 to Fluvio topics.
 
-Supports both polling of atomic endpoints and streaming of HTTP responses when given the `stream` configuration option.
-When polling, an `interval` configuration option is accepted. When streaming a `delimiter` configuration option, which
-defaults to `'\n'`, is accepted.
+Supports polling of atomic endpoints, streaming of HTTP responses and connecting to websocket endpoints. 
+Polling periodically makes requests to HTTP endpoints. Each response is treated as a record, with the time between requests controlled by `interval`.
+Streaming Processes HTTP responses as data streams. Records are emitted for each encountered delimiter character (controlled by `stream`, '\n' by default).
+Websocket Establishes connections to websocket endpoints. Records are emitted for each incoming message received over the websocket connection.
 
 Supports HTTP/1.0, HTTP/1.1, HTTP/2.0 protocols.
 
@@ -17,8 +18,8 @@ Tutorial for [HTTP to SQL Pipeline](https://www.fluvio.io/docs/tutorials/data-pi
 | :------------| :--------------------------| :-----  | :----------------------------------------------------------------------------------------- |
 | interval     | 10s                        | String  | Interval between each HTTP Request. This is in the form of "1s", "10ms", "1m", "1ns", etc. |
 | method       | GET                        | String  | GET, POST, PUT, HEAD                                                                       |
-| endpoint     | -                          | String  | HTTP URL endpoint                                                                          |
-| headers      | -                          | Array\<String\> | Request header(s) "Key:Value" pairs                                                  |
+| endpoint     | -                          | String  | HTTP URL endpoint. Use `ws://` for websocket URLs.                                         |
+| headers      | -                          | Array\<String\> | Request header(s) "Key:Value" pairs                                                |
 | body         | -                          | String  | Request body e.g. in POST                                                                  |
 | user-agent   | "fluvio/http-source 0.1.0" | String  | Request user-agent                                                                         |
 | output_type  | text                       | String  | `text` = UTF-8 String Output, `json` = UTF-8 JSON Serialized String                        |
@@ -148,4 +149,19 @@ http:
   method: GET
   stream: true
   delimiter: "\n\n"
+```
+
+### Websocket Mode
+Connect to a websocket endpoint using a `ws://` URL. When reading text messages, they are emitted as equivalent records. Binary messages are initially attempted to be converted into strings.
+
+```yaml
+# config-example.yaml
+apiVersion: 0.1.0
+meta:
+  version: 0.3.2
+  name: websocket-connector
+  type: http-source
+  topic: websocket-updates
+http:
+  endpoint: ws://websocket.example/websocket
 ```

--- a/crates/http-source/Cargo.toml
+++ b/crates/http-source/Cargo.toml
@@ -12,6 +12,7 @@ async-std = { workspace = true }
 serde = { workspace = true }
 
 async-trait = { version = "0.1", default-features = false }
+async-stream = "0.3.5"
 bytes =  { version = "1.1.0", default-features = false }
 futures = { version = "0.3", default-features = false }
 anyhow = { version = "1.0" }
@@ -22,6 +23,8 @@ url = { version = "2.4", default-features = false, features = ["serde"] }
 humantime-serde = { version = "1.1", default-features = false }
 tokio-stream = { version = "0.1", default-features = false, features = ["time"] }
 tokio = { version = "1.36", default-features = false, features = ["time"] }
+tokio-tungstenite = "*"
+tungstenite = "*"
 encoding_rs = { version = "0.8", default-features = false }
 mime = { version = "0.3", default-features = false }
 

--- a/crates/http-source/src/config.rs
+++ b/crates/http-source/src/config.rs
@@ -58,16 +58,8 @@ pub(crate) struct HttpConfig {
 #[derive(Debug)]
 pub(crate) struct WebSocketConfig {
     pub(crate) subscription_message: Option<String>,
-    pub(crate) reconnection_policy: Option<ReconnectionPolicy>,
     // TODO: pub(crate) max_message_size: Option<usize>,
     pub(crate) ping_interval_ms: Option<u64>,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub(crate) struct ReconnectionPolicy {
-    pub(crate) max_retries: u32,
-    pub(crate) base_delay_ms: usize,
-    pub(crate) max_delay_ms: usize,
 }
 
 #[derive(Debug, Default, Deserialize, Clone, Copy)]

--- a/crates/http-source/src/config.rs
+++ b/crates/http-source/src/config.rs
@@ -49,7 +49,27 @@ pub(crate) struct HttpConfig {
     /// Response output type: text | json
     #[serde(default = "Default::default")]
     pub output_type: OutputType,
+
+    #[serde(default = "Default::default")]
+    pub websocket_config: Option<WebSocketConfig>
 }
+
+#[connector(config, name = "websocket")]
+#[derive(Debug)]
+pub(crate) struct WebSocketConfig {
+    pub(crate) subscription_message: Option<String>,
+    pub(crate) reconnection_policy: Option<ReconnectionPolicy>,
+    // TODO: pub(crate) max_message_size: Option<usize>, 
+    pub(crate) ping_interval_ms: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct ReconnectionPolicy {
+    pub(crate) max_retries: u32,
+    pub(crate) base_delay_ms: usize,
+    pub(crate) max_delay_ms: usize,
+}
+
 
 #[derive(Debug, Default, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]

--- a/crates/http-source/src/config.rs
+++ b/crates/http-source/src/config.rs
@@ -51,7 +51,7 @@ pub(crate) struct HttpConfig {
     pub output_type: OutputType,
 
     #[serde(default = "Default::default")]
-    pub websocket_config: Option<WebSocketConfig>
+    pub websocket_config: Option<WebSocketConfig>,
 }
 
 #[connector(config, name = "websocket")]
@@ -59,7 +59,7 @@ pub(crate) struct HttpConfig {
 pub(crate) struct WebSocketConfig {
     pub(crate) subscription_message: Option<String>,
     pub(crate) reconnection_policy: Option<ReconnectionPolicy>,
-    // TODO: pub(crate) max_message_size: Option<usize>, 
+    // TODO: pub(crate) max_message_size: Option<usize>,
     pub(crate) ping_interval_ms: Option<u64>,
 }
 
@@ -69,7 +69,6 @@ pub(crate) struct ReconnectionPolicy {
     pub(crate) base_delay_ms: usize,
     pub(crate) max_delay_ms: usize,
 }
-
 
 #[derive(Debug, Default, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]

--- a/crates/http-source/src/http_streaming_source.rs
+++ b/crates/http-source/src/http_streaming_source.rs
@@ -14,44 +14,14 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use crate::{
-    backoff::Backoff,
     config::HttpConfig,
     formatter::{formatter, Formatter, HttpResponseMetadata, HttpResponseRecord},
-    BACKOFF_LIMIT,
 };
-
-use futures::Stream;
 
 pub(crate) struct HttpStreamingSource {
     request: RequestBuilder,
     delimiter: Vec<u8>,
     formatter: Arc<dyn Formatter + Sync + Send>,
-}
-
-pub(crate) async fn reconnect_stream_with_backoff(
-    config: &HttpConfig,
-    backoff: &mut Backoff,
-) -> Result<std::pin::Pin<Box<dyn Stream<Item = String>>>> {
-    let wait = backoff.next();
-
-    if wait > BACKOFF_LIMIT {
-        error!("Max retry reached, exiting");
-    }
-
-    match HttpStreamingSource::new(config)?.connect(None).await {
-        Ok(stream) => Ok(stream),
-        Err(err) => {
-            warn!(
-                "Error connecting to streaming source: \"{}\", reconnecting in {}.",
-                err,
-                humantime::format_duration(wait)
-            );
-
-            async_std::task::sleep(wait).await;
-
-            Err(err)
-        }
-    }
 }
 
 #[async_trait]

--- a/crates/http-source/src/main.rs
+++ b/crates/http-source/src/main.rs
@@ -1,9 +1,9 @@
 mod backoff;
 mod config;
 mod formatter;
-mod websocket_source;
 mod http_streaming_source;
 mod source;
+mod websocket_source;
 
 use std::time::Duration;
 
@@ -11,13 +11,13 @@ use anyhow::Result;
 use async_std::stream::StreamExt;
 use backoff::Backoff;
 use config::HttpConfig;
-use url::Url;
 use fluvio::{RecordKey, TopicProducer};
 use fluvio_connector_common::{
     connector,
     tracing::{debug, info, trace, warn},
     Source,
 };
+use url::Url;
 
 use crate::http_streaming_source::reconnect_stream_with_backoff;
 use source::HttpSource;

--- a/crates/http-source/src/websocket_source.rs
+++ b/crates/http-source/src/websocket_source.rs
@@ -1,0 +1,217 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+use anyhow::{Result,Context};
+use async_trait::async_trait;
+use fluvio::Offset;
+use fluvio_connector_common::{tracing::{error, debug, info}, Source};
+use futures::{self, stream::{LocalBoxStream, SplitSink}, SinkExt};
+use tokio::net::TcpStream;
+use tokio::time::{sleep, Duration};
+use tokio_stream::{wrappers::IntervalStream, StreamExt};
+use tokio_tungstenite::{connect_async, MaybeTlsStream, tungstenite::protocol::Message, WebSocketStream};
+
+use crate::config::{HttpConfig, ReconnectionPolicy};
+
+pub(crate) struct WebSocketSource {
+    request: WSRequest,
+    ping_interval_ms: u64,
+    max_retries: u32
+}
+
+#[derive(Clone)]
+struct WSRequest {
+    url: Url,
+    subscription_message: Option<String>,
+    reconnection_policy: Option<ReconnectionPolicy>
+}
+
+type Transport = MaybeTlsStream<TcpStream>;
+
+#[async_trait]
+trait PingStream {
+    async fn ping(&mut self) -> Result<()>;
+}
+
+struct WSPingOnlySink(SplitSink<WebSocketStream<Transport>, Message>);
+
+#[async_trait]
+impl PingStream for WSPingOnlySink {
+    async fn ping(self: &mut Self) -> Result<()> {
+        self.0.send(Message::Ping(Vec::new())).await
+        .map_err(|e| {
+            error!("Failed to send ping: {}", e);
+            anyhow::Error::new(e)
+        })?;
+    
+        debug!("Ping sent");
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct WebSocketEvent {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_bytes: Option<Vec<u8>>,
+}
+
+// Computes the backoff delay using an exponential strategy
+fn compute_backoff(attempt: usize, base_delay_ms: usize, max_delay_ms: usize) -> usize {
+    let exponent = 2usize.pow(attempt.min(31) as u32); // Prevent overflow, cap exponent at 2^31
+    let delay = base_delay_ms.saturating_mul(exponent);
+    delay.min(max_delay_ms)
+}
+
+async fn establish_connection(request: WSRequest, max_retries: u32) -> Result<WebSocketStream<Transport>> {
+    let mut attempt = 0;
+
+    loop {
+        match connect_async(&request.url).await {
+            Ok((mut ws_stream, _)) => {
+                info!("WebSocket connected to {}", &request.url);
+                if let Some(message) = request.subscription_message.as_ref() {
+                    ws_stream.send(Message::Text(message.to_owned())).await?;
+                }
+                return Ok(ws_stream);
+            }
+            Err(e) => {
+                error!("WebSocket connection error on attempt {}: {}", attempt, e);
+                attempt += 1;
+
+                if attempt >= max_retries { 
+                    break
+                }
+
+                if let Some(reconnection_policy) = request.reconnection_policy.as_ref() {
+                    let delay = compute_backoff(attempt as usize, reconnection_policy.base_delay_ms as usize, reconnection_policy.max_delay_ms as usize);
+                    sleep(Duration::from_millis(delay as u64)).await;
+                }
+            }
+        }
+    }
+
+    Err(anyhow::Error::new(
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Failed to establish WebSocket connection after {} attempts", attempt),
+        )
+    ))
+}
+
+async fn websocket_writer_and_stream<'a> (request: WSRequest, max_retries: u32) -> Result<(
+    WSPingOnlySink, 
+    LocalBoxStream<'a, String>
+)> {
+    let ws_stream = establish_connection(request, max_retries).await
+    .context("Failed to establish WebSocket connection")?;
+
+    let (write_half, read_half) = futures::stream::StreamExt::split(ws_stream);
+    let stream = futures::stream::StreamExt::filter_map(read_half, |message_result| {
+        async move {
+            match message_result {
+                Ok(message) => {
+                    match message {
+                        Message::Text(text) => {
+                            info!("Got message: {}", text);
+                            Some(text)
+                        }
+                        Message::Binary(data) => {
+                            if let Ok(text) = String::from_utf8(data) {
+                                Some(text)
+                            } else {
+                                error!("Received binary data that could not be converted to UTF-8 text");
+                                None
+                            }
+                        }
+
+                        Message::Ping(_) | Message::Pong(_) => {
+                            // upon receiving ping messages tungstenite queues pong replies automatically
+                            debug!("Received ping/pong message, connection is alive");
+                            None
+                        }
+                        Message::Close(_) => {
+                            info!("Received WebSocket Close frame");
+                            None
+                        }
+                        _ => {
+                            // Ignore other message types
+                            None
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("WebSocket read error: {}", e);
+                    // Depending on the error you may choose to stop and close or try to reconnect
+                    None
+                }
+            }
+        }
+    });
+
+    Ok((WSPingOnlySink(write_half), futures::stream::StreamExt::boxed_local(stream)))
+}
+
+impl WebSocketSource {
+    pub(crate) fn new(config: &HttpConfig) -> Result<Self> {
+        let ws_config = config.websocket_config.as_ref();
+
+        let reconnection_policy = ws_config.and_then(
+            |ws| ws.reconnection_policy.as_ref()
+        );
+        
+        Ok(Self {
+            request: WSRequest {
+                url: Url::parse(&config.endpoint.resolve()?).context("unable to parse http endpoint")?,
+                subscription_message: ws_config.and_then(|c| c.subscription_message.to_owned()),
+                reconnection_policy: reconnection_policy.map(|c| c.clone())
+            },
+            ping_interval_ms: ws_config.and_then(|c| c.ping_interval_ms).unwrap_or(10_000),
+            max_retries: reconnection_policy.map(|c| c.max_retries).unwrap_or(1)
+
+        })
+    }
+
+    async fn reconnect_and_run<'a> (self) -> Result<LocalBoxStream<'a, String>> {
+        enum StreamElement {
+            Read(String),
+            PingInterval
+        }
+
+        let repeated_websocket = Box::pin(async_stream::stream! {
+            loop {
+                let ws_stream_result = websocket_writer_and_stream(self.request.clone(), self.max_retries).await;
+                if ws_stream_result.is_err() {
+                    break;
+                }
+                let (mut ping_only, ws_stream) = ws_stream_result.unwrap();
+
+                let mut ws_stream = ws_stream
+                    .map(|s| StreamElement::Read(s))
+                    .merge(IntervalStream::new(tokio::time::interval(Duration::from_millis(self.ping_interval_ms))).map(|_| StreamElement::PingInterval));
+
+                while let Some(item) = ws_stream.next().await {
+                    match item {
+                        StreamElement::Read(s) => yield s,
+                        StreamElement::PingInterval => {
+                            let ping_res = ping_only.ping().await;
+                            if ping_res.is_err() { break; }
+                        }
+                    }
+                }
+            }
+        });
+        
+        Ok(futures::stream::StreamExt::boxed_local(repeated_websocket))
+    }
+}
+
+#[async_trait]
+impl<'a> Source<'a, String> for WebSocketSource {
+    async fn connect(self, _offset: Option<Offset>) -> Result<LocalBoxStream<'a, String>> {
+        self
+            .reconnect_and_run()
+            .await
+            .context("Failed to run WebSocket connection")
+    }
+}

--- a/crates/http-source/src/websocket_source.rs
+++ b/crates/http-source/src/websocket_source.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use url::Url;
 use anyhow::{Result,Context};
 use async_trait::async_trait;
@@ -46,14 +45,6 @@ impl PingStream for WSPingOnlySink {
         debug!("Ping sent");
         Ok(())
     }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub(crate) struct WebSocketEvent {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_text: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_bytes: Option<Vec<u8>>,
 }
 
 // Computes the backoff delay using an exponential strategy

--- a/crates/http-source/src/websocket_source.rs
+++ b/crates/http-source/src/websocket_source.rs
@@ -104,7 +104,6 @@ async fn websocket_writer_and_stream<'a> (request: WSRequest, max_retries: u32) 
                 Ok(message) => {
                     match message {
                         Message::Text(text) => {
-                            info!("Got message: {}", text);
                             Some(text)
                         }
                         Message::Binary(data) => {

--- a/crates/http-source/src/websocket_source.rs
+++ b/crates/http-source/src/websocket_source.rs
@@ -158,7 +158,6 @@ impl WebSocketSource {
             },
             ping_interval_ms: ws_config.and_then(|c| c.ping_interval_ms).unwrap_or(10_000),
             max_retries: reconnection_policy.map(|c| c.max_retries).unwrap_or(1)
-
         })
     }
 

--- a/crates/mock-http-server/Cargo.toml
+++ b/crates/mock-http-server/Cargo.toml
@@ -11,3 +11,4 @@ async-std = { workspace = true }
 serde = { workspace = true }
 
 tide = { version = "0.16" }
+tide-websockets = "0.4.0"

--- a/crates/mock-http-server/src/main.rs
+++ b/crates/mock-http-server/src/main.rs
@@ -5,6 +5,7 @@ use tide::prelude::*;
 use tide::sse;
 use tide::sse::Sender;
 use tide::Request;
+use tide_websockets::WebSocket;
 
 #[derive(Clone)]
 struct State {
@@ -28,6 +29,16 @@ async fn main() -> tide::Result<()> {
     app.at("/post").post(post_request);
     app.at("/stream_count_updates")
         .get(sse::endpoint(stream_count_updates));
+    app.at("/websocket")
+    .get(WebSocket::new(|_request, stream| async move {      
+        for i in 1..11 {
+            stream
+                .send_string(format!("Hello, Fluvio! - {}", i))
+                .await?;
+        }
+        Ok(())
+    }));
+
     app.listen("127.0.0.1:8080").await?;
     Ok(())
 }

--- a/crates/mock-http-server/src/main.rs
+++ b/crates/mock-http-server/src/main.rs
@@ -30,14 +30,14 @@ async fn main() -> tide::Result<()> {
     app.at("/stream_count_updates")
         .get(sse::endpoint(stream_count_updates));
     app.at("/websocket")
-    .get(WebSocket::new(|_request, stream| async move {      
-        for i in 1..11 {
-            stream
-                .send_string(format!("Hello, Fluvio! - {}", i))
-                .await?;
-        }
-        Ok(())
-    }));
+        .get(WebSocket::new(|_request, stream| async move {
+            for i in 1..11 {
+                stream
+                    .send_string(format!("Hello, Fluvio! - {}", i))
+                    .await?;
+            }
+            Ok(())
+        }));
 
     app.listen("127.0.0.1:8080").await?;
     Ok(())

--- a/tests/websocket-test-config.yaml
+++ b/tests/websocket-test-config.yaml
@@ -1,0 +1,10 @@
+meta:
+  version: latest
+  name: http-json-connector
+  type: websocket-source
+  topic: TOPIC
+  create_topic: false
+  producer:
+    linger: 0ms
+http:
+  endpoint: ws://127.0.0.1:8080/websocket

--- a/tests/websocket-test.bats
+++ b/tests/websocket-test.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+setup() {
+    cargo build -p mock-http-server
+    ./target/debug/mock-http-server & disown
+    MOCK_PID=$!
+    FILE=$(mktemp)
+    cp ./tests/websocket-test-config.yaml $FILE
+    UUID=$(uuidgen | awk '{print tolower($0)}')
+    TOPIC=${UUID}-topic
+    fluvio topic create $TOPIC
+
+    sed -i.BAK "s/TOPIC/${TOPIC}/g" $FILE
+    cat $FILE
+
+    cargo build -p http-source
+    ./target/debug/http-source --config $FILE & disown
+    CONNECTOR_PID=$!
+}
+
+teardown() {
+    fluvio topic delete $TOPIC
+    kill $MOCK_PID
+    kill $CONNECTOR_PID
+}
+
+@test "websocket-connector-test" {
+    count=1
+    echo "Starting consumer on topic $TOPIC"
+    sleep 13
+
+    fluvio consume -B -d $TOPIC | while read input; do
+        expected="Hello, Fluvio! - $count"
+        echo $input = $expected
+        [ "$input" = "$expected" ]
+        count=$(($count + 1))
+        if [ $count -eq 10 ]; then
+            break;
+        fi
+    done
+
+}
+


### PR DESCRIPTION
Details in this discussion: https://github.com/infinyon/http-source-connector/issues/142

Code is based on https://github.com/mrasputin/fluvio-websocket-source-connector with a refactor to move from channels to streams, which aligns more with the approach in this code.

This connector is a sibling of http-source and http-streaming-source, and can be invoked by using a ws:// URL.
Since it's a separated code, there is more work to be done and decisions to be made about handling config values like delimiter, headers, and more, which are currently ignored.
