### PR TITLE
Send multiple messages to WebSocket sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This is an example of simple connector config file for polling an endpoint:
 # config-example.yaml
 apiVersion: 0.1.0
 meta:
-  version: 0.3.8
+  version: 0.4.0
   name: cat-facts
   type: http-source
   topic: cat-facts
@@ -82,7 +82,7 @@ Fluvio HTTP Source Connector supports Secrets in the `endpoint` and in the `head
 # config-example.yaml
 apiVersion: 0.1.0
 meta:
-  version: 0.3.8
+  version: 0.4.0
   name: cat-facts
   type: http-source
   topic: cat-facts
@@ -108,7 +108,7 @@ The previous example can be extended to add extra transformations to outgoing re
 # config-example.yaml
 apiVersion: 0.1.0
 meta:
-  version: 0.3.8
+  version: 0.4.0
   name: cat-facts
   type: http-source
   topic: cat-facts
@@ -148,7 +148,7 @@ Provide the `stream` configuration option to enable streaming mode with `delimit
 # config-example.yaml
 apiVersion: 0.1.0
 meta:
-  version: 0.3.8
+  version: 0.4.0
   name: wiki-updates
   type: http-source
   topic: wiki-updates
@@ -166,7 +166,7 @@ Connect to a websocket endpoint using a `ws://` URL. When reading text messages,
 # config-example.yaml
 apiVersion: 0.1.0
 meta:
-  version: 0.3.8
+  version: 0.4.0
   name: websocket-connector
   type: http-source
   topic: websocket-updates

--- a/README.md
+++ b/README.md
@@ -15,18 +15,19 @@ See [docs](https://www.fluvio.io/connectors/inbound/http/) here.
 Tutorial for [HTTP to SQL Pipeline](https://www.fluvio.io/docs/tutorials/data-pipeline/).
 
 ### Configuration
-| Option       | default                    | type    | description                                                                                |
-| :------------| :--------------------------| :-----  | :----------------------------------------------------------------------------------------- |
-| interval     | 10s                        | String  | Interval between each HTTP Request. This is in the form of "1s", "10ms", "1m", "1ns", etc. |
-| method       | GET                        | String  | GET, POST, PUT, HEAD                                                                       |
-| endpoint     | -                          | String  | HTTP URL endpoint. Use `ws://` for websocket URLs.                                         |
-| headers      | -                          | Array\<String\> | Request header(s) "Key:Value" pairs                                                |
-| body         | -                          | String  | Request body e.g. in POST                                                                  |
-| user-agent   | "fluvio/http-source 0.1.0" | String  | Request user-agent                                                                         |
-| output_type  | text                       | String  | `text` = UTF-8 String Output, `json` = UTF-8 JSON Serialized String                        |
-| output_parts | body                       | String  | `body` = body only, `full` = all status, header and body parts                             |
-| stream       | false                      | bool    | Flag to indicate HTTP streaming mode                                                       |
-| delimiter    | '\n'                       | String  | Delimiter to separate records when producing from an HTTP streaming endpoint               |
+| Option           | default                    | type            | description                                                                                |
+|:-----------------|:---------------------------|:----------------|:-------------------------------------------------------------------------------------------|
+| interval         | 10s                        | String          | Interval between each HTTP Request. This is in the form of "1s", "10ms", "1m", "1ns", etc. |
+| method           | GET                        | String          | GET, POST, PUT, HEAD                                                                       |
+| endpoint         | -                          | String          | HTTP URL endpoint. Use `ws://` for websocket URLs.                                         |
+| headers          | -                          | Array\<String\> | Request header(s) "Key:Value" pairs                                                        |
+| body             | -                          | String          | Request body e.g. in POST                                                                  |
+| user-agent       | "fluvio/http-source 0.1.0" | String          | Request user-agent                                                                         |
+| output_type      | text                       | String          | `text` = UTF-8 String Output, `json` = UTF-8 JSON Serialized String                        |
+| output_parts     | body                       | String          | `body` = body only, `full` = all status, header and body parts                             |
+| stream           | false                      | bool            | Flag to indicate HTTP streaming mode                                                       |
+| delimiter        | '\n'                       | String          | Delimiter to separate records when producing from an HTTP streaming endpoint               |
+| websocket_config | {}                         | Object          | WebSocket configuration object. See below.                                                 |
 
 #### Record Type Output
 | Matrix                                                      | Output                                  |
@@ -36,6 +37,12 @@ Tutorial for [HTTP to SQL Pipeline](https://www.fluvio.io/docs/tutorials/data-pi
 | output_type = json, output_parts = body (default)           | Only the "body" in JSON struct          |
 | output_type = json, output_parts = full                     | HTTP "status", "body" and "header" JSON |
 
+#### WebSocket Configuration
+| Option                | default | type            | description                                                                                                                                                  |
+|:----------------------|:--------|:----------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| subscription_messages | []      | Array\<String\> | List of messages to send to the server after connection is established.                                                                                      |
+| ping_interval_ms      | 10000   | int             | Interval in milliseconds to send ping messages to the server.                                                                                                |
+| subscription_message  | -       | String          | (deprecated) Message to send to the server after connection is established. If provided with subscription_messages, subscription_message will be sent first. |
 
 ### Usage Example
 

--- a/crates/http-source/Connector.toml
+++ b/crates/http-source/Connector.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-source"
 group = "infinyon"
-version = "0.3.8"
+version = "0.4.0"
 apiVersion = "0.1.0"
 fluvio = "0.11.11"
 description = "HTTP source connector"

--- a/crates/http-source/src/config.rs
+++ b/crates/http-source/src/config.rs
@@ -58,6 +58,7 @@ pub(crate) struct HttpConfig {
 #[derive(Debug)]
 pub(crate) struct WebSocketConfig {
     pub(crate) subscription_message: Option<String>,
+    pub(crate) subscription_messages: Option<Vec<String>>,
     // TODO: pub(crate) max_message_size: Option<usize>,
     pub(crate) ping_interval_ms: Option<u64>,
 }

--- a/crates/http-source/src/config.rs
+++ b/crates/http-source/src/config.rs
@@ -58,7 +58,7 @@ pub(crate) struct HttpConfig {
 #[derive(Debug)]
 pub(crate) struct WebSocketConfig {
     pub(crate) subscription_message: Option<String>,
-    pub(crate) subscription_messages: Option<Vec<String>>,
+    pub(crate) subscription_messages: Vec<String>,
     // TODO: pub(crate) max_message_size: Option<usize>,
     pub(crate) ping_interval_ms: Option<u64>,
 }

--- a/crates/mock-http-server/src/main.rs
+++ b/crates/mock-http-server/src/main.rs
@@ -1,3 +1,4 @@
+use async_std::stream::StreamExt;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::thread::sleep;
@@ -5,7 +6,7 @@ use tide::prelude::*;
 use tide::sse;
 use tide::sse::Sender;
 use tide::Request;
-use tide_websockets::WebSocket;
+use tide_websockets::{Message, WebSocket};
 
 #[derive(Clone)]
 struct State {
@@ -36,6 +37,14 @@ async fn main() -> tide::Result<()> {
                     .send_string(format!("Hello, Fluvio! - {}", i))
                     .await?;
             }
+            Ok(())
+        }));
+    app.at("/websocket-echo")
+        .get(WebSocket::new(|_request, mut stream| async move {
+            while let Some(Ok(Message::Text(input))) = stream.next().await {
+                stream.send_string(input.to_uppercase()).await?;
+            }
+
             Ok(())
         }));
 

--- a/tests/websocket-subscription-test-config.yaml
+++ b/tests/websocket-subscription-test-config.yaml
@@ -1,0 +1,22 @@
+meta:
+  version: latest
+  name: websocket-messages-connector
+  type: websocket-source
+  topic: TOPIC
+  create_topic: false
+  producer:
+    linger: 0ms
+http:
+  endpoint: ws://127.0.0.1:8080/websocket-echo
+  websocket_config:
+    subscription_messages:
+      - 'hello 1'
+      - 'hello 2'
+      - 'hello 3'
+      - 'hello 4'
+      - 'hello 5'
+      - 'hello 6'
+      - 'hello 7'
+      - 'hello 8'
+      - 'hello 9'
+      - 'hello 10'

--- a/tests/websocket-subscription-test.bats
+++ b/tests/websocket-subscription-test.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+setup() {
+    cargo build -p mock-http-server
+    ./target/debug/mock-http-server & disown
+    MOCK_PID=$!
+    FILE=$(mktemp)
+    cp ./tests/websocket-subscription-test-config.yaml $FILE
+    UUID=$(uuidgen | awk '{print tolower($0)}')
+    TOPIC=${UUID}-topic
+    fluvio topic create $TOPIC
+
+    sed -i.BAK "s/TOPIC/${TOPIC}/g" $FILE
+    cat $FILE
+
+    cargo build -p http-source
+    ./target/debug/http-source --config $FILE & disown
+    CONNECTOR_PID=$!
+}
+
+teardown() {
+    fluvio topic delete $TOPIC
+    kill $MOCK_PID
+    kill $CONNECTOR_PID
+}
+
+@test "websocket-connector-test" {
+    echo "Starting consumer on topic $TOPIC"
+    sleep 13
+
+    fluvio consume -B -d $TOPIC | while read input; do
+        expected="HELLO $count"
+        echo $input = $expected
+        [ "$input" = "$expected" ]
+        count=$(($count + 1))
+        if [ $count -eq 10 ]; then
+            break;
+        fi
+    done
+}
+

--- a/tests/websocket-subscription-test.bats
+++ b/tests/websocket-subscription-test.bats
@@ -25,6 +25,7 @@ teardown() {
 }
 
 @test "websocket-connector-test" {
+    count=1
     echo "Starting consumer on topic $TOPIC"
     sleep 13
 


### PR DESCRIPTION
This updates the WebSocket connector to add a `subscription_messages` (plural) config to `websocket_config`, which allows sending multiple subscription messages to a WebSocket source endpoint.

I have made some design decisions here that I'm open to modification on:
* `subscription_messages` is a new config key separate from `subscription_message`. If `subscription_message` is used, a deprecation warning appears suggesting using `subscription_messages`.
  * Alternative: change the type to an enum or similar as necessary to support a single string or array of strings and accept both under the `subscription_message` key. Not sure if possible with the YAML parser—I didn't try.
  * Alternative: accept both, with `subscription_message` appearing at the beginning or end of the message list.

I find this necessary for third-party WebSocket sources such as the [Polygon.io Options WebSocket endpoint](https://polygon.io/docs/options/ws_getting-started), which requires at least two messages, one for authentication and one per data channel.

For reference, my connection config for the Polygon.io options data looks like:

```yaml
meta:
  version: latest
  name: polygon-options-websocket-connector
  type: websocket-source
  topic: {TOPIC}
http:
  endpoint: wss://socket.polygon.io/options
  websocket_config:
    subscription_messages:
      - '{"action":"auth","params":"{POLYGON_API_KEY}"}'
      - '{"action":"subscribe","params":"T.*,A.*,AM.*"}'
```