### PR TITLE
Bugfix: Accept Option<Vec<String>> for subscription_messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This is an example of simple connector config file for polling an endpoint:
 # config-example.yaml
 apiVersion: 0.1.0
 meta:
-  version: 0.4.0
+  version: 0.4.1
   name: cat-facts
   type: http-source
   topic: cat-facts
@@ -82,7 +82,7 @@ Fluvio HTTP Source Connector supports Secrets in the `endpoint` and in the `head
 # config-example.yaml
 apiVersion: 0.1.0
 meta:
-  version: 0.4.0
+  version: 0.4.1
   name: cat-facts
   type: http-source
   topic: cat-facts
@@ -108,7 +108,7 @@ The previous example can be extended to add extra transformations to outgoing re
 # config-example.yaml
 apiVersion: 0.1.0
 meta:
-  version: 0.4.0
+  version: 0.4.1
   name: cat-facts
   type: http-source
   topic: cat-facts
@@ -148,7 +148,7 @@ Provide the `stream` configuration option to enable streaming mode with `delimit
 # config-example.yaml
 apiVersion: 0.1.0
 meta:
-  version: 0.4.0
+  version: 0.4.1
   name: wiki-updates
   type: http-source
   topic: wiki-updates
@@ -166,7 +166,7 @@ Connect to a websocket endpoint using a `ws://` URL. When reading text messages,
 # config-example.yaml
 apiVersion: 0.1.0
 meta:
-  version: 0.4.0
+  version: 0.4.1
   name: websocket-connector
   type: http-source
   topic: websocket-updates

--- a/crates/http-source/Connector.toml
+++ b/crates/http-source/Connector.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-source"
 group = "infinyon"
-version = "0.4.0"
+version = "0.4.1"
 apiVersion = "0.1.0"
 fluvio = "0.11.12"
 description = "HTTP source connector"

--- a/crates/http-source/src/config.rs
+++ b/crates/http-source/src/config.rs
@@ -58,7 +58,7 @@ pub(crate) struct HttpConfig {
 #[derive(Debug)]
 pub(crate) struct WebSocketConfig {
     pub(crate) subscription_message: Option<String>,
-    pub(crate) subscription_messages: Vec<String>,
+    pub(crate) subscription_messages: Option<Vec<String>>,
     // TODO: pub(crate) max_message_size: Option<usize>,
     pub(crate) ping_interval_ms: Option<u64>,
 }

--- a/crates/http-source/src/websocket_source.rs
+++ b/crates/http-source/src/websocket_source.rs
@@ -153,7 +153,10 @@ impl WebSocketSource {
         }
 
         let subscription_messages = if let Some(ws_config) = ws_config {
-            let mut messages = ws_config.subscription_messages.clone();
+            let mut messages = ws_config
+                .subscription_messages
+                .clone()
+                .unwrap_or_else(Vec::new);
             if let Some(message) = ws_config.subscription_message.as_ref() {
                 warn!("websocket_config.subscription_message is deprecated, please use subscription_messages instead. if both are provided, subscription_message will be sent first.");
                 messages.insert(0, message.to_owned());


### PR DESCRIPTION
This is necessary to avoid an error on passing a `websocket_config` without providing a `subscription_messages` value. Without `websocket_config`, this is currently working fine, but if `websocket_config` is not `None`, then there's an error about `subscription_messages` missing.

Apologies, this was a later change that didn't get caught by the tests.